### PR TITLE
bfs: Use set instead of array to track `searched` items

### DIFF
--- a/algorithms/bfs.js
+++ b/algorithms/bfs.js
@@ -4,18 +4,18 @@ function isSeller(name) {
 
 export default function bfs(graph, name) {
   const queue = [...graph[name]];
-  const searched = [];
+  const searched = new Set();
 
   while (queue.length > 0) {
     const person = queue.shift();
 
-    if (!searched.includes(person)) {
+    if (!searched.has(person)) {
       if (isSeller(person)) {
         return person;
       }
 
       queue.push(...graph[person]);
-      searched.push(person);
+      searched.add(person);
     }
   }
 

--- a/cosmos/__snapshots__/cosmos.test.js.snap
+++ b/cosmos/__snapshots__/cosmos.test.js.snap
@@ -6310,7 +6310,7 @@ exports[`test page:bfs 1`] = `
                        
                       2. 
                     </span>
-                      const searched = [];
+                      const searched = new Set();
                   </div>
                   <div>
                     <span
@@ -6355,7 +6355,7 @@ exports[`test page:bfs 1`] = `
                        
                       7. 
                     </span>
-                        if (!searched.includes(person)) {
+                        if (!searched.has(person)) {
                   </div>
                   <div>
                     <span
@@ -6405,7 +6405,7 @@ exports[`test page:bfs 1`] = `
                       data-jsx={4083623245}>
                       13. 
                     </span>
-                          searched.push(person);
+                          searched.add(person);
                   </div>
                   <div>
                     <span
@@ -13057,7 +13057,7 @@ exports[`test source-code:bfs 1`] = `
        
       2. 
     </span>
-      const searched = [];
+      const searched = new Set();
   </div>
   <div>
     <span
@@ -13102,7 +13102,7 @@ exports[`test source-code:bfs 1`] = `
        
       7. 
     </span>
-        if (!searched.includes(person)) {
+        if (!searched.has(person)) {
   </div>
   <div>
     <span
@@ -13152,7 +13152,7 @@ exports[`test source-code:bfs 1`] = `
       data-jsx={4083623245}>
       13. 
     </span>
-          searched.push(person);
+          searched.add(person);
   </div>
   <div>
     <span


### PR DESCRIPTION
`Set#has` runs in `O(1)` time whereas `Array#includes` runs in `O(n)` time.